### PR TITLE
Introduce uploaded files cache with verbose log

### DIFF
--- a/lib/asset_sync/asset_sync.rb
+++ b/lib/asset_sync/asset_sync.rb
@@ -53,11 +53,11 @@ module AssetSync
     end
 
     def warn(msg)
-      stderr.puts msg
+      stderr.puts "#{Time.new.to_s}: #{msg}"
     end
 
     def log(msg)
-      stdout.puts msg unless config.log_silently?
+      stdout.puts "#{Time.new.to_s}: #{msg}" unless config.log_silently?
     end
 
     def enabled?

--- a/lib/asset_sync/asset_sync.rb
+++ b/lib/asset_sync/asset_sync.rb
@@ -53,11 +53,11 @@ module AssetSync
     end
 
     def warn(msg)
-      stderr.puts "#{Time.new.to_s}: #{msg}"
+      stderr.puts "[#{Time.new}] #{msg}"
     end
 
     def log(msg)
-      stdout.puts "#{Time.new.to_s}: #{msg}" unless config.log_silently?
+      stdout.puts "[#{Time.new}] #{msg}" unless config.log_silently?
     end
 
     def enabled?

--- a/lib/asset_sync/config.rb
+++ b/lib/asset_sync/config.rb
@@ -25,6 +25,7 @@ module AssetSync
     attr_accessor :cdn_distribution_id
     attr_accessor :cache_asset_regexps
     attr_accessor :include_manifest
+    attr_accessor :cache_file
 
     # FOG configuration
     attr_accessor :fog_provider          # Currently Supported ['AWS', 'Rackspace']
@@ -75,6 +76,7 @@ module AssetSync
       self.invalidate = []
       self.cache_asset_regexps = []
       self.include_manifest = false
+      self.cache_file = nil
       @additional_local_file_paths_procs = []
 
       load_yml! if defined?(::Rails) && yml_exists?

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -269,9 +269,12 @@ module AssetSync
       end
 
       if self.cache_file
+        log "start writing cache file to #{self.cache_file}"
         File.open(self.cache_file, 'w') do |file|
-          file.write(local_files_to_upload.to_json)
+          uploaded = local_files_to_upload + remote_files
+          file.write(uploaded.to_json)
         end
+        log "finished writing cache file to #{self.cache_file}"
       end
     end
 

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -37,6 +37,10 @@ module AssetSync
       self.config.public_path
     end
 
+    def cache_file
+      self.config.cache_file
+    end
+
     def ignored_files
       expand_file_names(self.config.ignored_files)
     end

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -239,7 +239,7 @@ module AssetSync
 
     def upload_files
       remote_files = []
-      if self.cache_file
+      if self.cache_file && File.file?(self.cache_file)
         remote_files = JSON.parse(File.read(self.cache_file))
       else
         # get a fresh list of remote files

--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -244,7 +244,9 @@ module AssetSync
     def upload_files
       remote_files = []
       if self.cache_file && File.file?(self.cache_file)
+        log "start loading cache #{self.cache_file}"
         remote_files = JSON.parse(File.read(self.cache_file))
+        log "finished loading cache #{self.cache_file}"
       else
         # get a fresh list of remote files
         remote_files = ignore_existing_remote_files? ? [] : get_remote_files


### PR DESCRIPTION
## WHY

I have several problems using this gem.
- Too slow when having so many candidate files to upload
  - Also too slow to fetch uploaded files list
- No way to identify the bottleneck
  - It can print logs but without time

## WHAT

This PR enables us to speed up asset_sync time after the second time

- [x] Print log with time
- [x] Inject logs print to identify bottlenecks
- [x] Add `cache_file` option to store uploaded files
  - [x] Read the specified file when exists
  - [x] Write uploaded files to the specified file